### PR TITLE
Fix video issue with ScummVM running on FrameBuffer

### DIFF
--- a/drivers/video/fbdev/MiSTer_fb.c
+++ b/drivers/video/fbdev/MiSTer_fb.c
@@ -177,7 +177,7 @@ static int setup_fb_info(struct fb_dev *fbdev)
 		/* settings for 32bit pixels */
 		info->var.bits_per_pixel = 32;
 
-		info->var.red.offset = 8;
+		info->var.red.offset = 0;
 		info->var.green.offset = 8;
 		info->var.blue.offset = 16;
 


### PR DESCRIPTION
This fixes the video issue I'm having with ScummVM running on the FrameBuffer.

Thanks to Alanswx for spotting this and saying it looks suspect :) 

I have been doing some testing and the colors do look correct now...