### PR TITLE
Support for TP-Link - Archer T2U Nano using RTL8821 driver

### DIFF
--- a/drivers/net/wireless/realtek/rtl8821AU/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8821AU/os_dep/linux/usb_intf.c
@@ -325,6 +325,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x7392, 0xA811),.driver_info = RTL8821}, /* Edimax - Edimax */
 	{USB_DEVICE(0x7392, 0xA812),.driver_info = RTL8821}, /* Edimax - EW-7811UTC */
 	{USB_DEVICE(0x7392, 0xA813),.driver_info = RTL8821}, /* Edimax - EW-7811UAC */
+	{USB_DEVICE(0x2357, 0x011E),.driver_info = RTL8821}, /* TP-Link - Archer T2U Nano */
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
This device is apparently RTL8821, but vendor/product ID so far unknown for Linux.

According to this:
https://github.com/aircrack-ng/rtl8812au/issues/334#issuecomment-495289004

We can use RTL8821 for this device. Checked! It works!