### PR TITLE
Force Joysticks polling rate to 1000Hz for improved controller latency

### DIFF
--- a/drivers/hid/usbhid/hid-core.c
+++ b/drivers/hid/usbhid/hid-core.c
@@ -1108,8 +1108,7 @@ static int usbhid_start(struct hid_device *hid)
 				interval = hid_mousepoll_interval;
 			break;
 		case HID_GD_JOYSTICK:
-			if (hid_jspoll_interval > 0)
-				interval = hid_jspoll_interval;
+				interval = 1;
 			break;
 		case HID_GD_KEYBOARD:
 			if (hid_kbpoll_interval > 0)


### PR DESCRIPTION
"usbhid.jspoll=1" does not have any effect and linux still polls at the requested rate of controllers.
Having it at 1000Hz can eliminate some of the needs to get those commercial LLAPI adapters as it can pull the results down to near 1ms.

Modifying the module "drivers/hid/usbhid/hid-core.c" should yield the same result as the parameter seems to have no effect.

Test results of 1000Hz polling rate improving controller's input latency across all tested controllers documented here: https://medium.com/@WydD/controller-input-lag-how-to-measure-it-1ebfd2c9d60