### PR TITLE
XInput polling rate param + Qanba Obsidian XInput mode support

### DIFF
--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -417,6 +417,7 @@ static const signed short xpad_abs_triggers[] = {
 	{ XPAD_XBOXONE_VENDOR_PROTOCOL((vend), 208) }
 
 static const struct usb_device_id xpad_table[] = {
+	XPAD_XBOXONE_VENDOR(0x2c22),		/* Qanba Joysticks */
 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* X-Box USB-IF not approved class */
 	XPAD_XBOX360_VENDOR(0x0079),		/* GPD Win 2 Controller */
 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster X-Box 360 controllers */

--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -118,6 +118,10 @@ static bool auto_poweroff = true;
 module_param(auto_poweroff, bool, S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(auto_poweroff, "Power off wireless controllers on suspend");
 
+static unsigned int xpad_poll_interval;
+module_param_named(cpoll, xpad_poll_interval, uint, S_IWUSR | S_IRUGO);
+MODULE_PARM_DESC(cpoll, "Polling interval (ms) of XInput controllers");
+
 static const struct xpad_device {
 	u16 idVendor;
 	u16 idProduct;
@@ -125,6 +129,7 @@ static const struct xpad_device {
 	u8 mapping;
 	u8 xtype;
 } xpad_device[] = {
+	{ 0x2c22, 0x2303, "Qanba Obsidian Arcade Joystick", 0, XTYPE_XBOXONE }, /* The left and right triggers share the same Z-axis on PC mode (XInput) = Xbox One */
 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
 	{ 0x044f, 0x0f00, "Thrustmaster Wheel", 0, XTYPE_XBOX },
 	{ 0x044f, 0x0f03, "Thrustmaster Wheel", 0, XTYPE_XBOX },
@@ -1090,6 +1095,7 @@ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad,
 			struct usb_endpoint_descriptor *ep_irq_out)
 {
 	int error;
+	int interval;
 
 	if (xpad->xtype == XTYPE_UNKNOWN)
 		return 0;
@@ -1109,10 +1115,12 @@ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad,
 		goto err_free_coherent;
 	}
 
+	interval = cpoll > 0 ? cpoll : ep_irq_out->bInterval;
+
 	usb_fill_int_urb(xpad->irq_out, xpad->udev,
 			 usb_sndintpipe(xpad->udev, ep_irq_out->bEndpointAddress),
 			 xpad->odata, XPAD_PKT_LEN,
-			 xpad_irq_out, xpad, ep_irq_out->bInterval);
+			 xpad_irq_out, xpad, interval);
 	xpad->irq_out->transfer_dma = xpad->odata_dma;
 	xpad->irq_out->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
 
@@ -1719,6 +1727,7 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 	struct usb_xpad *xpad;
 	struct usb_endpoint_descriptor *ep_irq_in, *ep_irq_out;
 	int i, error;
+	int interval;
 
 	if (intf->cur_altsetting->desc.bNumEndpoints != 2)
 		return -ENODEV;
@@ -1806,14 +1815,21 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 		goto err_free_in_urb;
 	}
 
+
 	error = xpad_init_output(intf, xpad, ep_irq_out);
 	if (error)
 		goto err_free_in_urb;
 
+    /* 
+     * User-defined parameter to change the polling rate.
+     * Tests show the kernel will still poll at a higher rate if the value is too high (slow rate) on some controllers.
+     */
+	interval = cpoll > 0 ? cpoll : ep_irq_in->bInterval;
+
 	usb_fill_int_urb(xpad->irq_in, udev,
 			 usb_rcvintpipe(udev, ep_irq_in->bEndpointAddress),
 			 xpad->idata, XPAD_PKT_LEN, xpad_irq_in,
-			 xpad, ep_irq_in->bInterval);
+			 xpad, interval);
 	xpad->irq_in->transfer_dma = xpad->idata_dma;
 	xpad->irq_in->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
 

--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -118,8 +118,8 @@ static bool auto_poweroff = true;
 module_param(auto_poweroff, bool, S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(auto_poweroff, "Power off wireless controllers on suspend");
 
-static unsigned int xpad_poll_interval;
-module_param_named(cpoll, xpad_poll_interval, uint, S_IWUSR | S_IRUGO);
+static unsigned int cpoll = 0;
+module_param(cpoll, uint, S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(cpoll, "Polling interval (ms) of XInput controllers");
 
 static const struct xpad_device {
@@ -1116,6 +1116,7 @@ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad,
 	}
 
 	interval = cpoll > 0 ? cpoll : ep_irq_out->bInterval;
+	pr_info("XPAD: original out->bInterval=%d, new interval=%d\n", ep_irq_out->bInterval, interval);
 
 	usb_fill_int_urb(xpad->irq_out, xpad->udev,
 			 usb_sndintpipe(xpad->udev, ep_irq_out->bEndpointAddress),
@@ -1825,6 +1826,7 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
      * Tests show the kernel will still poll at a higher rate if the value is too high (slow rate) on some controllers.
      */
 	interval = cpoll > 0 ? cpoll : ep_irq_in->bInterval;
+	pr_info("XPAD: original in->bInterval=%d, new interval=%d\n", ep_irq_in->bInterval, interval);
 
 	usb_fill_int_urb(xpad->irq_in, udev,
 			 usb_rcvintpipe(udev, ep_irq_in->bEndpointAddress),

--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -120,7 +120,7 @@ MODULE_PARM_DESC(auto_poweroff, "Power off wireless controllers on suspend");
 
 static unsigned int cpoll = 0;
 module_param(cpoll, uint, S_IWUSR | S_IRUGO);
-MODULE_PARM_DESC(cpoll, "Polling interval (ms) of XInput controllers");
+MODULE_PARM_DESC(cpoll, "Polling interval of XInput controllers");
 
 static const struct xpad_device {
 	u16 idVendor;
@@ -129,7 +129,8 @@ static const struct xpad_device {
 	u8 mapping;
 	u8 xtype;
 } xpad_device[] = {
-	{ 0x2c22, 0x2303, "Qanba Obsidian Arcade Joystick", 0, XTYPE_XBOXONE }, /* The left and right triggers share the same Z-axis on PC mode (XInput) = Xbox One */
+	/* The left and right triggers share the same Z-axis on PC mode (XInput) = Xbox One */
+	{ 0x2c22, 0x2303, "Qanba Obsidian Arcade Joystick", 0, XTYPE_XBOX360 },  /* Works better in XBOX360 */
 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
 	{ 0x044f, 0x0f00, "Thrustmaster Wheel", 0, XTYPE_XBOX },
 	{ 0x044f, 0x0f03, "Thrustmaster Wheel", 0, XTYPE_XBOX },
@@ -417,8 +418,8 @@ static const signed short xpad_abs_triggers[] = {
 	{ XPAD_XBOXONE_VENDOR_PROTOCOL((vend), 208) }
 
 static const struct usb_device_id xpad_table[] = {
-	XPAD_XBOXONE_VENDOR(0x2c22),		/* Qanba Joysticks */
 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* X-Box USB-IF not approved class */
+	XPAD_XBOX360_VENDOR(0x2c22),		/* Qanba Joysticks */
 	XPAD_XBOX360_VENDOR(0x0079),		/* GPD Win 2 Controller */
 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster X-Box 360 controllers */
 	XPAD_XBOX360_VENDOR(0x045e),		/* Microsoft X-Box 360 controllers */
@@ -1117,7 +1118,7 @@ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad,
 	}
 
 	interval = cpoll > 0 ? cpoll : ep_irq_out->bInterval;
-	pr_info("XPAD: original out->bInterval=%d, new interval=%d\n", ep_irq_out->bInterval, interval);
+	pr_info("XPAD: original out.bInterval=%d -> new interval=%d\n", ep_irq_out->bInterval, interval);
 
 	usb_fill_int_urb(xpad->irq_out, xpad->udev,
 			 usb_sndintpipe(xpad->udev, ep_irq_out->bEndpointAddress),
@@ -1740,6 +1741,7 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 			break;
 	}
 
+
 	xpad = kzalloc(sizeof(struct usb_xpad), GFP_KERNEL);
 	if (!xpad)
 		return -ENOMEM;
@@ -1827,7 +1829,7 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
      * Tests show the kernel will still poll at a higher rate if the value is too high (slow rate) on some controllers.
      */
 	interval = cpoll > 0 ? cpoll : ep_irq_in->bInterval;
-	pr_info("XPAD: original in->bInterval=%d, new interval=%d\n", ep_irq_in->bInterval, interval);
+	pr_info("XPAD: original in.bInterval=%d -> new interval=%d\n", ep_irq_in->bInterval, interval);
 
 	usb_fill_int_urb(xpad->irq_in, udev,
 			 usb_rcvintpipe(udev, ep_irq_in->bEndpointAddress),


### PR DESCRIPTION
This adds a new parameter you can set in u-boot.txt ("xpad.cpoll") that does pretty much the same thing as "usbhid.jspoll", but for XInput pads as they do not use the USB HID driver.

It also adds/fixes PC mode (XInput) for a quite popular high-tier joystick among fighting gamers, Qanba Obsidian!

This has been thoroughly tested and here are also some great results taking advantage of the new polling rate param set to 1: 
https://cdn.discordapp.com/attachments/497145588446396416/646923923614859304/Standard_vs_1ms_polling.png
(Thanks jorge_!)

The results is pretty impressive for a USB controller! Similar model (M30 Bluetooth) was also tested and showed about 3ms improvement (10ms -> 7ms) on average.

