### PR TITLE
Remove XBox One Wireless Adapter USB IDs from mt76 driver to allow 'xow' driver compatibility.

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt76x2_usb.c
+++ b/drivers/net/wireless/mediatek/mt76/mt76x2_usb.c
@@ -27,7 +27,6 @@ static const struct usb_device_id mt76x2u_device_table[] = {
 	{ USB_DEVICE(0x057c, 0x8503) },	/* Avm FRITZ!WLAN AC860 */
 	{ USB_DEVICE(0x7392, 0xb711) },	/* Edimax EW 7722 UAC */
 	{ USB_DEVICE(0x0846, 0x9053) },	/* Netgear A6210 */
-	{ USB_DEVICE(0x045e, 0x02e6) },	/* XBox One Wireless Adapter */
 	{ },
 };
 


### PR DESCRIPTION
The XBox One Wireless Adapter requires the 'xow' user-mode driver (https://github.com/medusalix/xow) to work under Linux.

However, the adapter uses the MediaTek MT76 chipset which is also used by other wireless/bluetooth adapters.

If the Linux kernel loads the MT76 device driver (mt76x2u, etc) then xow (and libusb) cannot communicate with the adapter.  There are three options to solve this problem:

1) Remove mt76 driver from the kernel completely.  (CONFIG_MT76xxxx=n)  This has the disadvantage of disabling support for other wireless dongles that use this chipset.
2) Remove the USB IDs from the MT76 driver so it doesn't automatically detect the XBox Wireless Adapter and load the driver.
3) Compile the mt76 driver as a loadable kernel module so it could be blacklisted/disabled as needed.

This pull request is for approach 2.

Approach 3 would be more future-proof but MiSTer doesn't appear to use any loadable kernel modules so this would be inconsistent with the rest of the system.