### PR TITLE
Allow additional serial devices over USB

### DIFF
--- a/arch/arm/configs/MiSTer_defconfig
+++ b/arch/arm/configs/MiSTer_defconfig
@@ -2372,7 +2372,7 @@ CONFIG_USB_OTG=y
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=y
 # CONFIG_USB_PRINTER is not set
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set


### PR DESCRIPTION
When working with external microcontrollers with the MiSTer platform, it is convenient to communicate over a serial connection. I see some existing projects which use /dev/ttyUSB serial connections, which are supported. However, /dev/ttyACM isn't supported in the current kernel. This pull request would enable the needed kernel driver. I believe it would be a benefit to a portion of the community.

I tested the change with Adafruit controllers and it successfully enabled serial support for those devices.

I also believe this adds approximately 10KB to the compiled kernel.