### PR TITLE
Fix module compile for Fanatec driver

### DIFF
--- a/drivers/hid/Makefile
+++ b/drivers/hid/Makefile
@@ -156,3 +156,4 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
 obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
 
 obj-$(CONFIG_JOYSTICK_XONE)		+= xone/
+

--- a/drivers/hid/Makefile
+++ b/drivers/hid/Makefile
@@ -47,7 +47,8 @@ obj-$(CONFIG_HID_ELECOM)	+= hid-elecom.o
 obj-$(CONFIG_HID_ELO)		+= hid-elo.o
 obj-$(CONFIG_HID_EZKEY)		+= hid-ezkey.o
 obj-$(CONFIG_HID_FT260)		+= hid-ft260.o
-obj-$(CONFIG_HID_FTEC)      += hid-ftec.o hid-ftecff.o
+obj-$(CONFIG_HID_FTEC)		+= hid-fanatec.o
+hid-fanatec-$(CONFIG_HID_FTEC)	+= hid-ftec.o hid-ftecff.o
 obj-$(CONFIG_HID_GEMBIRD)	+= hid-gembird.o
 obj-$(CONFIG_HID_GFRM)		+= hid-gfrm.o
 obj-$(CONFIG_HID_GLORIOUS)  += hid-glorious.o
@@ -155,4 +156,3 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
 obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
 
 obj-$(CONFIG_JOYSTICK_XONE)		+= xone/
-


### PR DESCRIPTION
@amstan noticed that with my last change, if you set `CONFIG_HID_FTEC=m`, the compile breaks. The compile was okay previously with `CONFIG_HID_FTEC=y` only, which was in the default config, so I didn't notice the problem.

This small PR fixes the compile when `CONFIG_HID_FTEC=m`.

### Test plan
1. Tested first with no changes to the default config. The driver still initializes correctly.
2. Tested second with a kernel and module compiled with `CONFIG_HID_FTEC=m`. Did `insmod hid-fanatec.ko` and the driver initializes correctly.