### PR TITLE
defconfig: enable macvlan support

### DIFF
--- a/arch/arm/configs/MiSTer_defconfig
+++ b/arch/arm/configs/MiSTer_defconfig
@@ -1299,7 +1299,7 @@ CONFIG_NET_CORE=y
 # CONFIG_WIREGUARD is not set
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_TEAM is not set
-# CONFIG_MACVLAN is not set
+CONFIG_MACVLAN=y
 # CONFIG_IPVLAN is not set
 # CONFIG_VXLAN is not set
 # CONFIG_GENEVE is not set


### PR DESCRIPTION
## Summary
- Enable `CONFIG_MACVLAN=y` in `MiSTer_defconfig`
- Allows creation of macvlan virtual network interfaces on MiSTer
- Enables multiple network services with distinct MAC addresses on a single physical interface

## Use case
Macvlan support is needed for scenarios such as container networking (Docker) and running isolated network services on the MiSTer platform. It creates virtual interfaces directly attached to the physical NIC with their own MAC addresses, providing near-native performance.

## Test plan
- [ ] Build kernel with updated defconfig
- [ ] Boot MiSTer with new kernel
- [ ] Verify `ip link add link eth0 name macvlan0 type macvlan mode bridge` works
- [ ] Verify network connectivity through macvlan interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)