### PR TITLE
config: enable CONFIG_TUN for tap device support

### DIFF
--- a/arch/arm/configs/MiSTer_defconfig
+++ b/arch/arm/configs/MiSTer_defconfig
@@ -1307,7 +1307,7 @@ CONFIG_MACVLAN=y
 # CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
 # CONFIG_VETH is not set
 # CONFIG_NLMON is not set


### PR DESCRIPTION
# config: enable CONFIG_TUN for tap device support

One line: `# CONFIG_TUN is not set` → `CONFIG_TUN=y`.

## Why

`CONFIG_MACVLAN` is already enabled, which covers giving a guest interface its
own MAC address on **wired** eth0. That approach does not work on WiFi: an
802.11 station cannot emit frames bearing a second source MAC, so a macvlan
child on `wlan0` has its traffic dropped by the access point. Routing or NAT
through a **tap** device is the standard way around it — and tap needs
`CONFIG_TUN`, which is currently off.

The case that prompted this is the emulated Commodore A2065 Amiga Ethernet card
for the Minimig core (MiSTer-devel/Main_MiSTer#1247), where the Amiga is given
its own address on the network. On wired eth0 that is done with macvlan, already
possible today. For MiSTer users on WiFi there is currently no route at all
without tap.

More generally this enables any host-side routed or NATed private subnet, which
is useful beyond this one core.

## Verification

Built for ARM (`MiSTer_defconfig`, `arm-none-linux-gnueabihf-` 10.2.1) and run on
a DE10-Nano. `/dev/net/tun` appears, `TUNSETIFF` succeeds, and a tap interface
carries traffic — here the Amiga pinging the MiSTer across a tap on a private
subnet:

```
4.DHO:> ping 192.168.10.1
PING 192.168.10.1 (192.168.10.1): 56 data bytes
64 bytes from 192.168.10.1: icmp_seq=0 ttl=64 time=5.177 ms
64 bytes from 192.168.10.1: icmp_seq=1 ttl=64 time=2.084 ms
64 bytes from 192.168.10.1: icmp_seq=2 ttl=64 time=2.071 ms
64 bytes from 192.168.10.1: icmp_seq=3 ttl=64 time=2.047 ms
64 bytes from 192.168.10.1: icmp_seq=4 ttl=64 time=2.067 ms
64 bytes from 192.168.10.1: icmp_seq=5 ttl=64 time=2.036 ms
64 bytes from 192.168.10.1: icmp_seq=6 ttl=64 time=2.086 ms
64 bytes from 192.168.10.1: icmp_seq=7 ttl=64 time=2.093 ms
64 bytes from 192.168.10.1: icmp_seq=8 ttl=64 time=2.061 ms

--- 192.168.10.1 ping statistics ---
9 packets transmitted, 9 packets received, 0% packet loss
round-trip min/avg/max = 2.036/2.414/5.177 ms
```

A 100 MB HTTP transfer over the same tap ran at 550 KB/s, the fastest of the
four delivery paths tested for that card — the ceiling there is the Amiga's
68000, not the tap.

Scope of what this proves: tap devices work and carry traffic. The WiFi routing
case is the motivation rather than something measured here — the board used has
no wireless interface, so onward NAT over `wlan0` was not exercised. Enabling
`CONFIG_TUN` is what makes it possible at all.

## Notes

- Built in (`=y`) rather than `=m`, matching `CONFIG_MACVLAN`. The MiSTer module
  directory is `5.15.1-MiSTer` while `uname -r` reports `5.15.1`, so module
  autoload is unreliable on this platform.
- `CONFIG_TUN_VNET_CROSS_LE` left off — only relevant to cross-endian vnet
  headers.
- Nothing is created by default: the driver is dormant until something opens
  `/dev/net/tun`.
- `MiSTer-v6.18` has `CONFIG_TUN` off as well and would want the same one-line
  change, if you want that branch kept in step.
