### PR TITLE
Bluetooth: add Mercusys MA550H support

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -438,6 +438,8 @@ static const struct usb_device_id blacklist_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 
 	/* Additional Realtek 8761BU Bluetooth devices */
+	{ USB_DEVICE(0x2c4e, 0x0115), .driver_info = BTUSB_REALTEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0b05, 0x190e), .driver_info = BTUSB_REALTEK |
 	  					     BTUSB_WIDEBAND_SPEECH },
 


### PR DESCRIPTION
Add USB ID 2c4e:0115 to the Realtek RTL8761BU device table.

The ID is used by Mercusys Bluetooth adapters including MA550H and MA530. And possibly others.

Tested on MiSTer with an MA550H, where the adapter initializes and operates correctly using the existing RTL8761BU firmware path.

https://www.spinics.net/lists/linux-bluetooth/msg128905.html