### PR TITLE
fbdev: MiSTer_fb: declare explicit fb_ops for read/write/mmap

### DIFF
--- a/drivers/video/fbdev/Kconfig
+++ b/drivers/video/fbdev/Kconfig
@@ -67,6 +67,8 @@ config FB_MISTER
 	select FB_SYS_FILLRECT
 	select FB_SYS_COPYAREA
 	select FB_SYS_IMAGEBLIT
+	select FB_SYSMEM_FOPS
+	select FB_IOMEM_FOPS
 	help
 	  This driver supports the MiSTer Frame Reader
 

--- a/drivers/video/fbdev/MiSTer_fb.c
+++ b/drivers/video/fbdev/MiSTer_fb.c
@@ -133,11 +133,14 @@ static int fb_ioctl(struct fb_info *info, unsigned int cmd, unsigned long arg)
 
 static struct fb_ops ops = {
 	.owner = THIS_MODULE,
+	.fb_read = fb_sys_read,
+	.fb_write = fb_sys_write,
 	.fb_fillrect = sys_fillrect,
 	.fb_copyarea = sys_copyarea,
 	.fb_imageblit = sys_imageblit,
 	.fb_setcolreg = fb_setcolreg,
 	.fb_ioctl = fb_ioctl,
+	.fb_mmap = fb_io_mmap,
 };
 
 static int setup_fb_info(struct fb_dev *fbdev)


### PR DESCRIPTION
**Overview** 

Kernel 6.8 removed core fbdev fallbacks for null file-I/O operations, causing mmap(/dev/fb0) to return -ENODEV and breaking userspace apps (like SDL 1.2 fbcon) that map the MiSTer framebuffer directly.

**Changes** 

- drivers/video/fbdev/mister_fb.c: Selected FB_SYSMEM_FOPS and FB_IOMEM_FOPS to supply the correct generic helpers (fb_sys_read, fb_sys_write, and fb_io_mmap), restoring write-combining smem_start mapping via pgprot_framebuffer.

**Validation**

Verified that mmap(/dev/fb0) successfully initializes on the latest Linux 6.8+ kernel release.