### PR TITLE
Input: xpad - opt-in 8BitDo reconnect experiment for issue #84

### DIFF
--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -129,6 +129,11 @@ static unsigned int cpoll = 0;
 module_param(cpoll, uint, S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(cpoll, "Polling interval of XInput controllers");
 
+static bool skip_8bitdo_init;
+module_param(skip_8bitdo_init, bool, 0644);
+MODULE_PARM_DESC(skip_8bitdo_init,
+		"Skip Xbox 360 initialization request for 2dc8:3106 (experimental)");
+
 static const struct xpad_device {
 	u16 idVendor;
 	u16 idProduct;
@@ -2094,7 +2099,10 @@ static int xpad_start_input(struct usb_xpad *xpad)
 			return error;
 		}
 	}
-	if (xpad->xtype == XTYPE_XBOX360) {
+	if (xpad->xtype == XTYPE_XBOX360 &&
+	    !(skip_8bitdo_init &&
+	      le16_to_cpu(xpad->udev->descriptor.idVendor) == 0x2dc8 &&
+	      le16_to_cpu(xpad->udev->descriptor.idProduct) == 0x3106)) {
 		/*
 		 * Some third-party controllers Xbox 360-style controllers
 		 * require this message to finish initialization.


### PR DESCRIPTION
Issue #84 reports that an 8BitDo Wireless Adapter 2 needs unplugging/replugging after boot and after its paired controller sleeps following the September 2026 update. This draft adds an **opt-in experiment for affected users to test**; the cause and workaround have not been verified on affected hardware.

The April 2025 MiSTer driver did not send the Xbox 360 vendor initialization request in `xpad_start_input()`. The new driver does, following upstream [05e632944373](https://patches.linaro.org/patch/690695/). This PR lets testers omit that request and compare reconnect behavior without removing initialization needed by other controller IDs.

`xpad.skip_8bitdo_init` defaults to false. Enabling it skips the request only for Xbox 360-mode devices with USB ID `2dc8:3106`. Input URBs, output/LED handling and other controller IDs retain their behavior. The [reported Adapter 2 IDs](https://github.com/paroj/xpad/issues/228) are `2dc8:3107` while idle and `2dc8:3106` when connected in XInput mode. Some Ultimate receivers also share `3106`, which is why this remains opt-in. It does not target Switch/DInput mode or a receiver stuck at its idle ID.

### Testing

Build this branch's `xpad` module against the **exact kernel build/configuration and symbol versions running on the target**, or use a matching kernel/modules build. Keep the original artifacts for rollback. The parameter is new in this PR; it does not exist in the current release. No release-compatible binary is attached.

1. Record the paired controller, adapter mode/firmware, `uname -a`, USB IDs (`lsusb`), `/proc/bus/input/devices`, and `dmesg` while failing, then after a successful replug. Save the failing log before replugging. Confirm `xpad` binds to `2dc8:3106`.
2. With the experimental module installed, first reproduce with the default setting (`N`). Enable the bypass with:

   ```sh
   echo Y > /sys/module/xpad/parameters/skip_8bitdo_init
   cat /sys/module/xpad/parameters/skip_8bitdo_init
   ```

3. Replug once to obtain a fresh input start, then test controller sleep/wake **without replugging**. Record whether the controller connects and whether input works, along with USB/input/kernel logs. Writing the parameter does not itself reset or recover an already hung receiver.
4. Repeat with `echo N > /sys/module/xpad/parameters/skip_8bitdo_init` and the same sequence. Please report both successful and unsuccessful results, including other devices sharing `3106`.

For the boot case, the option must be set **before the initial input open**: pass `skip_8bitdo_init=1` when the experimental module is loaded (for example `modprobe xpad skip_8bitdo_init=1` when it is not already loaded), or use the appropriate module-loader configuration. For built-in xpad use the kernel command-line option `xpad.skip_8bitdo_init=1`. A sysfs write after boot does not test the initial boot failure. Verify the value after boot. Remove any persistent test option when reverting to the original module.

An `unable to receive magic message` warning by itself is not proof of this hypothesis: the driver already treats that request's failure as nonfatal. If the bypass makes no difference, or the receiver never reaches `3106`, logs are needed to investigate enumeration, HID mode, power management or userspace discovery instead.

### Validation so far

- ARM external-module build with `W=1`: passed without compiler warnings, using an existing local `6.18.38+` kernel build's headers/configuration/symbols. This verifies compilation, not compatibility with the published `6.18.38-MiSTer` binary.
- Host harness compiled and executed the actual modified `xpad_start_input()` with USB transport stubs: 160 combinations covering IDs, controller types, opt-in/default behavior and transport failures passed. Checks include request contents, input-submission errors, Xbox One cleanup and nonfatal control-request errors.
- `git diff --check` passed; checkpatch reported zero errors and zero warnings.
- No affected-controller hardware test or new full kernel/rootfs build has been performed. Keep this draft pending reproducible A/B results.

Related to #84; deliberately does not close it.
