### PR TITLE
exfat: batch directory read-ahead

### DIFF
--- a/fs/exfat/dir.c
+++ b/fs/exfat/dir.c
@@ -6,6 +6,7 @@
 #include <linux/slab.h>
 #include <linux/compat.h>
 #include <linux/bio.h>
+#include <linux/blkdev.h>
 #include <linux/buffer_head.h>
 
 #include "exfat_raw.h"
@@ -644,9 +645,12 @@ static int exfat_dir_readahead(struct super_block *sb, sector_t sec)
 	bh = sb_find_get_block(sb, sec);
 	if (!bh || !buffer_uptodate(bh)) {
 		unsigned int i;
+		struct blk_plug plug;
 
+		blk_start_plug(&plug);
 		for (i = 0; i < ra_count; i++)
 			sb_breadahead(sb, (sector_t)(sec + i));
+		blk_finish_plug(&plug);
 	}
 	brelse(bh);
 	return 0;


### PR DESCRIPTION
Batch directory read-ahead with a block plug, matching the allocation-bitmap implementation. Preserve the existing read-ahead window and validation.

Tested on MiSTer with small and large directories; measurements are in the linked issue.

Fixes #87.
