### PR TITLE
Adapt Classic2USB and RetroZord HID force feedback support

### DIFF
--- a/drivers/hid/hid-google-stadiaff.c
+++ b/drivers/hid/hid-google-stadiaff.c
@@ -143,6 +143,8 @@ static void stadia_remove(struct hid_device *hid)
 static const struct hid_device_id stadia_devices[] = {
 	{ HID_USB_DEVICE(USB_VENDOR_ID_GOOGLE, USB_DEVICE_ID_GOOGLE_STADIA) },
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_GOOGLE, USB_DEVICE_ID_GOOGLE_STADIA) },
+	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC, 0x16d0, 0x1460) }, /* Classic2USB */
+	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC, 0x1209, 0x595a) }, /* RetroZord */
 	{ }
 };
 MODULE_DEVICE_TABLE(hid, stadia_devices);


### PR DESCRIPTION
Add Classic2USB (16d0:1460) and RetroZord (1209:595a) to the existing Stadia force-feedback driver's device table using HID_GROUP_GENERIC. Both use the existing Stadia rumble output report in compatible firmware.