### PR TITLE
HID: nintendo: skip baudrate setup for 8BitDo adapters

### DIFF
--- a/drivers/hid/hid-nintendo.c
+++ b/drivers/hid/hid-nintendo.c
@@ -691,6 +691,11 @@ static inline bool joycon_device_is_chrggrip(struct joycon_ctlr *ctlr)
 	return ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_CHRGGRIP;
 }
 
+static inline bool joycon_device_is_8bitdo(struct joycon_ctlr *ctlr)
+{
+	return !strncmp(ctlr->mac_addr_str, "E4:17:D8", 8);
+}
+
 /*
  * Controller type helpers
  *
@@ -2533,12 +2538,36 @@ static int joycon_read_info(struct joycon_ctlr *ctlr)
 static int joycon_init(struct hid_device *hdev)
 {
 	struct joycon_ctlr *ctlr = hid_get_drvdata(hdev);
+	bool usb_handshook = false;
 	int ret = 0;
 
 	mutex_lock(&ctlr->output_mutex);
 	/* if handshake command fails, assume ble pro controller */
 	if (joycon_using_usb(ctlr) && !joycon_send_usb(ctlr, JC_USB_CMD_HANDSHAKE, HZ)) {
 		hid_dbg(hdev, "detected USB controller\n");
+		usb_handshook = true;
+	} else if (jc_type_is_chrggrip(ctlr)) {
+		hid_err(hdev, "Failed charging grip handshake\n");
+		ret = -ETIMEDOUT;
+		goto out_unlock;
+	}
+
+	/* needed to retrieve the controller type */
+	ret = joycon_read_info(ctlr);
+	if (ret) {
+		hid_err(hdev, "Failed to retrieve controller info; ret=%d\n",
+			ret);
+		goto out_unlock;
+	}
+
+	/*
+	 * Only run the USB baudrate/handshake sequence if the initial handshake
+	 * was answered. A device that ignored it will not answer the second one
+	 * either, and that second failure is fatal. 8BitDo adapters do answer the
+	 * first handshake but do not implement the baudrate command, so they are
+	 * skipped as well.
+	 */
+	if (usb_handshook && !joycon_device_is_8bitdo(ctlr)) {
 		/* set baudrate for improved latency */
 		ret = joycon_send_usb(ctlr, JC_USB_CMD_BAUDRATE_3M, HZ);
 		if (ret) {
@@ -2559,18 +2588,6 @@ static int joycon_init(struct hid_device *hdev)
 		 * This doesn't send a response, so ignore the timeout.
 		 */
 		joycon_send_usb(ctlr, JC_USB_CMD_NO_TIMEOUT, HZ/10);
-	} else if (jc_type_is_chrggrip(ctlr)) {
-		hid_err(hdev, "Failed charging grip handshake\n");
-		ret = -ETIMEDOUT;
-		goto out_unlock;
-	}
-
-	/* needed to retrieve the controller type */
-	ret = joycon_read_info(ctlr);
-	if (ret) {
-		hid_err(hdev, "Failed to retrieve controller info; ret=%d\n",
-			ret);
-		goto out_unlock;
 	}
 
 	if (joycon_has_joysticks(ctlr)) {


### PR DESCRIPTION
> 🤖 **This description was written by Claude Opus 5, an AI model, on behalf of @kblood.** kblood asked me to investigate the bug and prepare this PR. The analysis and wording are mine, not kblood's.

Fixes the 8BitDo USB Wireless Adapter being unusable in Switch mode (`057e:2009`) on 6.18. Refs #84.

### The bug

In **Switch mode** the adapter is claimed by `hid-nintendo`, not `xpad`. The driver sends `JC_USB_CMD_BAUDRATE_3M`, which the adapter does not implement. Receiving it puts the adapter into an error state where it resets constantly. On this board that is **17 USB disconnect/re-enumerate cycles ~512 ms apart**, every handshake failing with `-EPROTO`, and the probe finally giving up with the HID device bound to **no driver at all**. Not even `hid-generic` binds, because `hid_generic_match()` declines while a specialised driver still matches the ID table. The result: no input device, no js node, dead gamepad.

`xpad.skip_8bitdo_init=1` cannot help here. That parameter is in `xpad`, which only sees the adapter in **X-Input** mode (`045e:028e` / `2dc8:3106`). The Switch-mode failure never reaches `xpad`.

This is not a 5.15→6.18 regression either. MiSTer's 5.15 ships its own out-of-tree `hid-nintendo` with `CONFIG_HID_NINTENDO=y`, and it fails one step *earlier*, because there a failed baudrate command is fatal rather than a warning.

### The fix

This is Michał Kopeć's (3mdeb) patch, [posted to linux-input on 2025-07-20](https://lore.kernel.org/linux-input/20250720143156.2563816-1-michal.kopec@3mdeb.com/) and never reviewed. It is ported unchanged apart from the one review fix below. It moves `joycon_read_info()` ahead of the USB baudrate/handshake block, and skips that block for devices whose Bluetooth MAC carries 8BitDo's `E4:17:D8` OUI.

The MAC is the only usable discriminator. The adapter's VID:PID, manufacturer string and product string are all copied from a genuine Switch Pro Controller, so a VID:PID quirk would break real Pro Controllers.

**Review fix (thanks @mcfbytes).** Kopeć's original re-guarded the block on `joycon_using_usb(ctlr) && !joycon_device_is_8bitdo(ctlr)`. That dropped vanilla's "first handshake succeeded" condition, so any USB `057e:2009` / `2017` / `200e` device that ignores the first handshake would now get a second one, which it would not answer either, and that failure is fatal. The block is now gated on `usb_handshook`, which records the first handshake's own result. The only behaviour change left is the intended one. The 8BitDo adapter does answer the first handshake, so its path is unchanged.

Authorship is preserved (`From: Michał Kopeć`). The commit carries no `Signed-off-by` from him, because he has not been asked to certify it, and writing a DCO sign-off in someone else's name is not appropriate. kblood signs off as submitter and tester. If this is wanted upstream rather than only in the MiSTer fork, Kopeć should be asked to re-post it himself, with the review fix included.

### Verified on hardware

DE10-Nano, 6.18.38, 1st-gen 8BitDo USB Wireless Adapter + SN30 Pro+. This was a controlled A/B with identical hardware state in both arms: same adapter, same adapter firmware, controller powered on and paired at enumeration, and a fresh replug before each arm. The kernel was the only variable.

| | stock | patched |
|---|---|---|
| disconnects / enumerations | 17 / 17 | **0 / 1** |
| `Failed to set baudrate` | 13 | **0** |
| `Failed handshake` | 13 | **0** |
| `probe - fail` | 18 | **0** |
| `controller MAC` logged | 0 | 1 — `E4:17:D8:F9:77:78` |
| HID driver bound | none | `nintendo` |
| Input devices | none | Pro Controller + IMU |
| Battery (read over the air) | no link | `Discharging` |

The MAC read back is the **adapter's own** address, not the paired controller's. That is the first hardware confirmation that the OUI prefix is a valid discriminator.

**What has not been re-tested:** the A/B above was run on the version *before* the review fix. The review fix does not change the 8BitDo path, and the patched file cross-compiles clean for arm with `W=1`, but the amended commit has not been booted on hardware yet. This PR stays a draft until it has.

**Caveat for anyone re-testing:** an arm only exercises the patch if `joycon_read_info()` succeeded, so check the log for a `controller MAC` line. An arm that logs `Failed to get joycon info; ret=-110` never reached the baudrate command and measured nothing.

### Out of scope

Separately, this adapter does not survive a USB port reset. That includes the port reset inside a warm reboot. Once it has been reset while running, only a physical replug recovers it. This is a different problem, and this patch does not address it. The details are in #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhHnXPREgKzDxyjWf91Y2D
