### PR TITLE
hid-nintendo: keep the " IMU" suffix on the motion device

### DIFF
--- a/drivers/hid/hid-nintendo.c
+++ b/drivers/hid/hid-nintendo.c
@@ -2106,7 +2106,8 @@ static int joycon_imu_input_create(struct joycon_ctlr *ctlr)
 	ctlr->imu_input->uniq = ctlr->mac_addr_str;
 	ctlr->imu_input->phys = hdev->phys;
 
-	imu_name = devm_kasprintf(&hdev->dev, GFP_KERNEL, "%s (IMU)", ctlr->input->name);
+	/* MiSTer: Main_MiSTer filters the motion device on the " IMU" suffix */
+	imu_name = devm_kasprintf(&hdev->dev, GFP_KERNEL, "%s IMU", ctlr->input->name);
 	if (!imu_name)
 		return -ENOMEM;
 


### PR DESCRIPTION
Mainline names it "%s (IMU)"; 5.15's fixed names all contained " IMU".
Main_MiSTer excludes the motion device with strstr(name, " IMU") and has
no other check, so on 6.18 the node is kept and, sharing the pad's
phys/uniq, is merged into it: accelerometer/gyro ABS_X/Y/RX/RY land on
the stick axes. Drop the parentheses.