### PR TITLE
MiSTer_fb: fix memremap() failure check

### DIFF
--- a/drivers/video/fbdev/MiSTer_fb.c
+++ b/drivers/video/fbdev/MiSTer_fb.c
@@ -258,11 +258,12 @@ static int fb_probe(struct platform_device *pdev)
 	fbdev->fb_res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (!fbdev->fb_res) return -ENODEV;
 
+	/* MiSTer: memremap() returns NULL on failure, never an ERR_PTR */
 	fbdev->fb_base = memremap(fbdev->fb_res->start, resource_size(fbdev->fb_res), MEMREMAP_WT);
-	if (IS_ERR(fbdev->fb_base))
+	if (!fbdev->fb_base)
 	{
-		dev_err(&pdev->dev, "devm_ioremap_resource fb failed\n");
-		return PTR_ERR(fbdev->fb_base);
+		dev_err(&pdev->dev, "memremap fb failed\n");
+		return -ENOMEM;
 	}
 
 	retval = setup_fb_info(fbdev);


### PR DESCRIPTION
memremap() returns NULL on failure, never an ERR_PTR, so the IS_ERR()
check (written for devm_ioremap_resource(), as its message suggests)
can never fire: probe continues with fb_base NULL and
register_framebuffer() oopses in fb_setcolreg() when fbcon takes over.

It has never triggered because mem=511M ends System RAM below the
0x22000000 window. Booting with more memory puts the window inside RAM,
which memremap(MEMREMAP_WT) refuses (WARN_ONCE, returns NULL); ioremap
also returns NULL if vmalloc space is exhausted. Check for NULL and fail
probe with -ENOMEM.